### PR TITLE
Remove `pry-byebug` development dependency

### DIFF
--- a/filewatcher-cli.gemspec
+++ b/filewatcher-cli.gemspec
@@ -35,8 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'clamp', '~> 1.3'
   spec.add_runtime_dependency 'filewatcher', '~> 2.0.0.beta2'
 
-  spec.add_development_dependency 'pry-byebug', '~> 3.9'
-
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'gem_toys', '~> 0.4.0'
   spec.add_development_dependency 'toys', '~> 0.11.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'pry-byebug'
+begin
+  require 'pry-byebug'
+rescue LoadError
+  nil
+end
 
 require 'simplecov'
 SimpleCov.start


### PR DESCRIPTION
It's not required, but not compatible with JRuby.