### PR TITLE
Return `extend self` instead of `module_function`

### DIFF
--- a/filewatcher-cli.gemspec
+++ b/filewatcher-cli.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5', '< 4'
 
   spec.add_runtime_dependency 'clamp', '~> 1.3'
-  spec.add_runtime_dependency 'filewatcher', '~> 2.0.0.beta3'
+  spec.add_runtime_dependency 'filewatcher', '~> 2.0.0.beta5'
 
   spec.add_development_dependency 'pry-byebug', '~> 3.9' unless RUBY_PLATFORM == 'java'
 

--- a/lib/filewatcher/cli/spec_helper.rb
+++ b/lib/filewatcher/cli/spec_helper.rb
@@ -9,13 +9,10 @@ class Filewatcher
       include Filewatcher::SpecHelper
 
       ENVIRONMENT_SPECS_COEFFICIENTS = {
-        ## There was `2` because of https://cirrus-ci.com/build/6442339705028608
-        ## Left for possible problems in the future
         lambda do
           RUBY_ENGINE == 'jruby' &&
-            ENV['CI'] &&
             is_a?(Filewatcher::CLI::SpecHelper::ShellWatchRun)
-        end => 1
+        end => 2
       }.freeze
 
       def environment_specs_coefficients

--- a/lib/filewatcher/cli/spec_helper.rb
+++ b/lib/filewatcher/cli/spec_helper.rb
@@ -6,21 +6,26 @@ class Filewatcher
   module CLI
     ## Helper for CLI specs
     module SpecHelper
-      extend Filewatcher::SpecHelper
+      include Filewatcher::SpecHelper
 
-      module_function
+      ENVIRONMENT_SPECS_COEFFICIENTS = {
+        ## There was `2` because of https://cirrus-ci.com/build/6442339705028608
+        ## Left for possible problems in the future
+        lambda do
+          RUBY_ENGINE == 'jruby' &&
+            ENV['CI'] &&
+            is_a?(Filewatcher::CLI::SpecHelper::ShellWatchRun)
+        end => 1
+      }.freeze
 
       def environment_specs_coefficients
-        @environment_specs_coefficients ||= super.merge(
-          ## There was `2` because of https://cirrus-ci.com/build/6442339705028608
-          ## Left for possible problems in the future
-          lambda do
-            RUBY_PLATFORM == 'java' &&
-              ENV['CI'] &&
-              is_a?(Filewatcher::CLI::SpecHelper::ShellWatchRun)
-          end => 1
-        )
+        @environment_specs_coefficients ||= super.merge ENVIRONMENT_SPECS_COEFFICIENTS
       end
+
+      ## https://github.com/rubocop/ruby-style-guide/issues/556#issuecomment-828672008
+      # rubocop:disable Style/ModuleFunction
+      extend self
+      # rubocop:enable Style/ModuleFunction
     end
   end
 end

--- a/spec/filewatcher/cli/spec_helper/shell_watch_run.rb
+++ b/spec/filewatcher/cli/spec_helper/shell_watch_run.rb
@@ -36,6 +36,10 @@ class Filewatcher
             debug "#{__method__}: File.exist?(DUMP_FILE) = #{dump_file_exists}"
             pid_state == 'S' && (!@options[:immediate] || dump_file_exists)
           end
+
+          ## Dump file can exists with `--immediate` option, but Filewatcher can not have time
+          ## to initialize `@last_snapshot` in main cycle.
+          wait
         end
 
         def stop

--- a/spec/filewatcher/cli/spec_helper/shell_watch_run.rb
+++ b/spec/filewatcher/cli/spec_helper/shell_watch_run.rb
@@ -30,7 +30,7 @@ class Filewatcher
 
           wait seconds: 3
 
-          wait do
+          wait seconds: 3 do
             debug "pid state = #{pid_state}"
             dump_file_exists = File.exist?(DUMP_FILE)
             debug "#{__method__}: File.exist?(DUMP_FILE) = #{dump_file_exists}"


### PR DESCRIPTION
See mentioned discussion.
Also it's more flexible with constants (blocks can be pretty huge).