### PR TITLE
Add additional coefficient for JRuby in CI

### DIFF
--- a/lib/filewatcher/cli/spec_helper.rb
+++ b/lib/filewatcher/cli/spec_helper.rb
@@ -11,9 +11,13 @@ class Filewatcher
       ENVIRONMENT_SPECS_COEFFICIENTS = {
         lambda do
           RUBY_ENGINE == 'jruby' &&
-            # ENV['CI'] &&
             is_a?(Filewatcher::CLI::SpecHelper::ShellWatchRun)
         end => 2,
+        lambda do
+          RUBY_ENGINE == 'jruby' &&
+            ENV['CI'] &&
+            is_a?(Filewatcher::CLI::SpecHelper::ShellWatchRun)
+        end => 1.5,
         lambda do
           RUBY_ENGINE == 'truffleruby' &&
             ENV['CI'] &&

--- a/lib/filewatcher/cli/spec_helper.rb
+++ b/lib/filewatcher/cli/spec_helper.rb
@@ -22,7 +22,7 @@ class Filewatcher
           RUBY_ENGINE == 'truffleruby' &&
             ENV['CI'] &&
             is_a?(Filewatcher::CLI::SpecHelper::ShellWatchRun)
-        end => 2
+        end => 3
       }.freeze
 
       def environment_specs_coefficients


### PR DESCRIPTION
There are fails from "ENV variables when file created"
and "`--restart-signal` option".